### PR TITLE
Update artifact upload paths in nuget-publish.yml

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -49,7 +49,9 @@ jobs:
           name: nuget-packages
           if-no-files-found: error
           retention-days: 7
-          path: ./nupkgs/*.nupkg
+          path: |
+            ./nupkgs/*.nupkg
+            ./nupkgs/*.snupkg
 
   publish-nuget:
     needs: build-and-test


### PR DESCRIPTION
Modified the `path` parameter in the `actions/upload-artifact@v4` step to include both `.nupkg` and `.snupkg` files, enabling the upload of additional NuGet package types during the artifact upload process.