### PR TITLE
Update target framework to net10 for all packages

### DIFF
--- a/samples/AzureSample/AzureSample.csproj
+++ b/samples/AzureSample/AzureSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>Infinity.Toolkit</UserSecretsId>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AzureServiceBusMessagingSample/AzureServiceBusMessagingSample.csproj
+++ b/samples/AzureServiceBusMessagingSample/AzureServiceBusMessagingSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/ConsoleLoggingFormatterSample/ConsoleLoggingFormatterSample.csproj
+++ b/samples/ConsoleLoggingFormatterSample/ConsoleLoggingFormatterSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/samples/FeatureModulesSample.Module1/FeatureModulesSample.Module1.csproj
+++ b/samples/FeatureModulesSample.Module1/FeatureModulesSample.Module1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -13,8 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/samples/FeatureModulesSample.Module1/SampleModule1.cs
+++ b/samples/FeatureModulesSample.Module1/SampleModule1.cs
@@ -16,7 +16,6 @@ public class SampleModule1 : WebFeatureModule
     public override void MapEndpoints(WebApplication app)
     {
         var group = app.MapGroup("/info")
-            .WithOpenApi()
             .WithTags("Info");
 
         group.MapGet("/systeminfo", GetSystemInfo)

--- a/samples/FeatureModulesSample/FeatureModulesSample.csproj
+++ b/samples/FeatureModulesSample/FeatureModulesSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -9,9 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.11.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/FeatureModulesSample/WeatherModule.cs
+++ b/samples/FeatureModulesSample/WeatherModule.cs
@@ -26,8 +26,7 @@ internal class WeatherModule : WebFeatureModule
 
             return forecast;
         })
-        .WithName("GetWeatherForecast")
-        .WithOpenApi();
+        .WithName("GetWeatherForecast");
     }
 }
 

--- a/samples/HandlersSample/HandlersSample.csproj
+++ b/samples/HandlersSample/HandlersSample.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scrutor" Version="6.1.0" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MediatorSample/MediatorSample.csproj
+++ b/samples/MediatorSample/MediatorSample.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/MessagingSample/MessagingSample.csproj
+++ b/samples/MessagingSample/MessagingSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -9,8 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/PipelineSample/PipelineSample.csproj
+++ b/samples/PipelineSample/PipelineSample.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SlackMessageBuilder/SlackMessageBuilder.csproj
+++ b/samples/SlackMessageBuilder/SlackMessageBuilder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Infinity.Toolkit.AspNetCore/Infinity.Toolkit.AspNetCore.csproj
+++ b/src/Infinity.Toolkit.AspNetCore/Infinity.Toolkit.AspNetCore.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<RootNamespace>Infinity.Toolkit.AspNetCore</RootNamespace>
-		<VersionPrefix>1.2.0</VersionPrefix>
+		<VersionPrefix>1.3.0</VersionPrefix>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -17,7 +17,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" NoWarn="NU1605" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" NoWarn="NU1605" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Infinity.Toolkit.Azure/Infinity.Toolkit.Azure.csproj
+++ b/src/Infinity.Toolkit.Azure/Infinity.Toolkit.Azure.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.Azure</RootNamespace>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
   </PropertyGroup>
   
   <ItemGroup>
@@ -14,9 +14,9 @@
   
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
-    <PackageReference Include="Microsoft.FeatureManagement" Version="4.3.0" />
+    <PackageReference Include="Microsoft.FeatureManagement" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Infinity.Toolkit.EntityFramework/Infinity.Toolkit.EntityFramework.csproj
+++ b/src/Infinity.Toolkit.EntityFramework/Infinity.Toolkit.EntityFramework.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.EntityFramework</RootNamespace>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Infinity.Toolkit.Experimental/Infinity.Toolkit.Experimental.csproj
+++ b/src/Infinity.Toolkit.Experimental/Infinity.Toolkit.Experimental.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.Experimental</RootNamespace>
@@ -18,9 +18,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.10" />
-    <PackageReference Include="Scrutor" Version="6.1.0" />
-    <PackageReference Include="System.Memory.Data" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.1" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+    <PackageReference Include="System.Memory.Data" Version="10.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Infinity.Toolkit.FeatureModules/Infinity.Toolkit.FeatureModules.csproj
+++ b/src/Infinity.Toolkit.FeatureModules/Infinity.Toolkit.FeatureModules.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.4.0</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <PackageId>Infinity.Toolkit.FeatureModules</PackageId>
     <Description>Infinity Toolkit Feature Modules let's you automatically register dependencies and endpoints in modules which simplifies development when you are working with vertical feature slices.</Description>
     <PackageTags>FeatureModules;VerticalSliceArchitecture;ModularMonoliths;MinimalApis</PackageTags>
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.10" />    
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infinity.Toolkit.IntegrationTests/Infinity.Toolkit.IntegrationTests.csproj
+++ b/src/Infinity.Toolkit.IntegrationTests/Infinity.Toolkit.IntegrationTests.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.IntegrationTests</RootNamespace>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.1</VersionPrefix>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" NoWarn="NU1605" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.10" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.8.0" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" NoWarn="NU1605" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.1" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.10.0" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infinity.Toolkit.IntegrationTests/SqlServerTestContainerFixture.cs
+++ b/src/Infinity.Toolkit.IntegrationTests/SqlServerTestContainerFixture.cs
@@ -15,8 +15,7 @@ public sealed class SqlServerTestContainerFixture<T, TContext> : WebApplicationF
 {
     public IConfiguration Configuration { get; private set; }
 
-    private readonly MsSqlContainer msSqlContainer = new MsSqlBuilder()
-      .WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+    private readonly MsSqlContainer msSqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2025-latest")
       .Build();
 
     public override async ValueTask DisposeAsync()

--- a/src/Infinity.Toolkit.LogFormatter/Infinity.Toolkit.LogFormatter.csproj
+++ b/src/Infinity.Toolkit.LogFormatter/Infinity.Toolkit.LogFormatter.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <PackageId>Infinity.Toolkit.LogFormatter</PackageId>
     <Description>A logging formatter that formats log messages with a Visual Studio Code inspired theme and Serilog like formatting.</Description>
     <PackageTags>Logging formatter</PackageTags>
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.10" />    
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Infinity.Toolkit.Messaging.AzureServiceBus/Infinity.Toolkit.Messaging.AzureServiceBus.csproj
+++ b/src/Infinity.Toolkit.Messaging.AzureServiceBus/Infinity.Toolkit.Messaging.AzureServiceBus.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <Description>Azure Service Bus Integration for Infinity.Toolkit.Messaging.</Description>
     <RootNamespace>Infinity.Toolkit.Messaging.AzureServiceBus</RootNamespace>
   </PropertyGroup>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
   </ItemGroup>
 

--- a/src/Infinity.Toolkit.Messaging/Infinity.Toolkit.Messaging.csproj
+++ b/src/Infinity.Toolkit.Messaging/Infinity.Toolkit.Messaging.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Infinity.Toolkit.Messaging</RootNamespace>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,17 +16,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.10" />
-    <PackageReference Include="OpenTelemetry" Version="1.13.1" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.13.1" />
-    <PackageReference Include="Scrutor" Version="6.1.0" />
-    <PackageReference Include="System.Memory.Data" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Api" Version="1.14.0" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+    <PackageReference Include="System.Memory.Data" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infinity.Toolkit.OpenApi/BearerSecuritySchemeDefinitionDocumentTransformer.cs
+++ b/src/Infinity.Toolkit.OpenApi/BearerSecuritySchemeDefinitionDocumentTransformer.cs
@@ -1,7 +1,5 @@
-﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.OpenApi;
+﻿using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi;
-using Microsoft.OpenApi.Models;
 
 namespace Infinity.Toolkit.OpenApi;
 
@@ -15,13 +13,12 @@ public sealed class BearerSecuritySchemeDefinitionDocumentTransformer : IOpenApi
         var securityScheme = new OpenApiSecurityScheme
         {
             Type = SecuritySchemeType.Http,
-            Name = JwtBearerDefaults.AuthenticationScheme,
-            Scheme = JwtBearerDefaults.AuthenticationScheme,
-            Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = JwtBearerDefaults.AuthenticationScheme }
+            Name = "bearer",
+            Scheme = "bearer",
         };
 
         document.Components ??= new();
-        document.Components.SecuritySchemes.Add(JwtBearerDefaults.AuthenticationScheme, securityScheme);
+        document.Components?.SecuritySchemes?.Add("bearer", securityScheme);
         return Task.CompletedTask;
     }
 }

--- a/src/Infinity.Toolkit.OpenApi/Infinity.Toolkit.OpenApi.csproj
+++ b/src/Infinity.Toolkit.OpenApi/Infinity.Toolkit.OpenApi.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.OpenApi</RootNamespace>
-    <VersionPrefix>0.1.4</VersionPrefix>
+    <VersionPrefix>0.1.5</VersionPrefix>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,9 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OpenApi" Version="1.6.28" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Infinity.Toolkit.Slack/Infinity.Toolkit.Slack.csproj
+++ b/src/Infinity.Toolkit.Slack/Infinity.Toolkit.Slack.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <PackageId>Infinity.Toolkit.Slack</PackageId>
     <Description>Useful tools for creating Slack messages using block kit as well as helpers for authenticating and verifying requests from Slack.</Description>
     <PackageTags>Slack;Toolkit;</PackageTags>

--- a/src/Infinity.Toolkit.TestUtils/Infinity.Toolkit.TestUtils.csproj
+++ b/src/Infinity.Toolkit.TestUtils/Infinity.Toolkit.TestUtils.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit.TestUtils</RootNamespace>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,14 +14,14 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageReference Include="xunit.v3.extensibility.core" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
+    <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Infinity.Toolkit/Infinity.Toolkit.csproj
+++ b/src/Infinity.Toolkit/Infinity.Toolkit.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0;net9.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Infinity.Toolkit</RootNamespace>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="9.0.10" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
-    <PackageReference Include="Scrutor" Version="6.1.0" />
-    <PackageReference Include="System.Memory.Data" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.1" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
+    <PackageReference Include="Scrutor" Version="7.0.0" />
+    <PackageReference Include="System.Memory.Data" Version="10.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/Infinity.Toolkit.Tests/Infinity.Toolkit.Tests.csproj
+++ b/tests/Infinity.Toolkit.Tests/Infinity.Toolkit.Tests.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.1.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This pull request updates the Infinity Toolkit codebase and sample projects to target .NET 10.0, along with upgrading related NuGet package dependencies to their latest major versions. It also removes multi-targeting for older .NET versions in several projects and makes minor code adjustments to sample modules. These changes ensure compatibility with .NET 10.0 and leverage improvements from newer package releases.

**.NET Version and Package Upgrades**

* Updated all project files to target `net10.0`, removing previous multi-targeting for `net9.0` and `net8.0` where applicable. [[1]](diffhunk://#diff-1fd4cad548507ba52c7affd99815405bc0aa2587032977ee547b8979346a8f6dL4-R8) [[2]](diffhunk://#diff-b5f61c24d8544441dbbd8d79cb064795c4ef49d7eb6765c4eeb674f4aeb8fe91L4-R8) [[3]](diffhunk://#diff-c7c117f4f364f1d8fb3794ff2a03a1ab15cfdaacffd5f0de8554e79b253cf140L4-R7) [[4]](diffhunk://#diff-4e29db9b9270fe42793b2edf139c9b02e7cc4a5a21ab4991a8376c101736f274L4-R7) [[5]](diffhunk://#diff-bac52d25bedaf8e29cd91b6408ce7bd47f576636ce03ff939065860d067caceaL4-R8) [[6]](diffhunk://#diff-1917d3aad4a9f062f8a566c796cbf509e3de054aa349f60e261f7c02bc684eb5L4-R17) [[7]](diffhunk://#diff-6ba2e52dd3e7d8c2096dbf4cbf730996f9b6dc86c878d31332533f07b3abfab5L4-R4)
* Upgraded major NuGet package references throughout the codebase to their latest versions compatible with .NET 10.0, including `Microsoft.AspNetCore.OpenApi`, `Microsoft.EntityFrameworkCore`, `Scrutor`, `Microsoft.Extensions.DependencyModel`, and others. [[1]](diffhunk://#diff-33da8eb46c7b44026198f6db5190ed626df4c1c6d66d45f5e85f5768dc804488L4-R13) [[2]](diffhunk://#diff-b5f61c24d8544441dbbd8d79cb064795c4ef49d7eb6765c4eeb674f4aeb8fe91L17-R19) [[3]](diffhunk://#diff-bac52d25bedaf8e29cd91b6408ce7bd47f576636ce03ff939065860d067caceaL17-R17) [[4]](diffhunk://#diff-6ba2e52dd3e7d8c2096dbf4cbf730996f9b6dc86c878d31332533f07b3abfab5L21-R23) [[5]](diffhunk://#diff-c7c117f4f364f1d8fb3794ff2a03a1ab15cfdaacffd5f0de8554e79b253cf140L22-R22) [[6]](diffhunk://#diff-4e29db9b9270fe42793b2edf139c9b02e7cc4a5a21ab4991a8376c101736f274L18-R19) [[7]](diffhunk://#diff-1917d3aad4a9f062f8a566c796cbf509e3de054aa349f60e261f7c02bc684eb5L4-R17) [[8]](diffhunk://#diff-77e98c24bd2b79b8f924ae77c8a258ddf63c3556463604d4c17fc13bef1179ffL4-R13) [[9]](diffhunk://#diff-fafcad9da197e561dcb6eba81247835ad289e8ad9ad12f807db91cb820cc86bdL4-R11) [[10]](diffhunk://#diff-d813796fd5ec2878b11b859a6f6f881f57728b1d102db6d2aa054f1ae0c7af28L5-R12) [[11]](diffhunk://#diff-f73e504a9259531004c46df3a19de2af9caa381b945f4b43fbbce81b7ba595eeL5-R12)

**Versioning and Container Updates**

* Incremented `VersionPrefix` properties for several toolkit projects to reflect new releases associated with the .NET 10.0 update. [[1]](diffhunk://#diff-1fd4cad548507ba52c7affd99815405bc0aa2587032977ee547b8979346a8f6dL4-R8) [[2]](diffhunk://#diff-b5f61c24d8544441dbbd8d79cb064795c4ef49d7eb6765c4eeb674f4aeb8fe91L4-R8) [[3]](diffhunk://#diff-c7c117f4f364f1d8fb3794ff2a03a1ab15cfdaacffd5f0de8554e79b253cf140L4-R7) [[4]](diffhunk://#diff-4e29db9b9270fe42793b2edf139c9b02e7cc4a5a21ab4991a8376c101736f274L4-R7) [[5]](diffhunk://#diff-bac52d25bedaf8e29cd91b6408ce7bd47f576636ce03ff939065860d067caceaL4-R8) [[6]](diffhunk://#diff-1917d3aad4a9f062f8a566c796cbf509e3de054aa349f60e261f7c02bc684eb5L4-R17)
* Updated SQL Server test container image to use `2025-latest` for integration tests, ensuring compatibility with the latest SQL Server release.

**Sample Code Adjustments**

* Removed `.WithOpenApi()` from endpoint mapping in sample modules, likely due to changes or deprecation in the OpenAPI integration API for .NET 10.0. [[1]](diffhunk://#diff-9f6ecf2726fbb7d24dfc4329ad6d8f59f618a7f51bf54439028d408ea71d33d6L19) [[2]](diffhunk://#diff-f3af37a5fb9163a8e0bc4ea85b3d7373f15bf8905abf299e449a4b7e1465c5a5L29-R29)
* Cleaned up package references in sample projects to remove unused or deprecated packages, streamlining dependencies for .NET 10.0. [[1]](diffhunk://#diff-beb528d393d9f6bac1b8c105f9fe300588404c8b23984e1c3b99ffdb57be81caL4-R12) [[2]](diffhunk://#diff-f7167f4c8e50e5b8de53bcf6cb58bd0aa9de430feaf03cf6772c42e3f00d8b5bL16-R16) [[3]](diffhunk://#diff-439ff2a78f0fb638561ebd3d8166af517fbc47b2643711edecff3711839a78b4L4-R12)

These updates collectively modernize the Infinity Toolkit ecosystem to fully support .NET 10.0 and its associated libraries.